### PR TITLE
Dockerized bts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Notebook checkpoints
+.ipynb_checkpoints
+
+# python cache files
+*.pyc
+
+
+custom_layer/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM tensorflow/tensorflow:1.13.2-gpu-jupyter
+
+# libcuda.so.1 is not available by default so we add what are probably stubs.
+# See https://github.com/tensorflow/tensorflow/issues/25865
+# If we leave the stubs linked later, then we get a weird error about CUDA
+# versions not matching, so we have to remove it later.
+ENV LD_LIBRARY_PATH_OLD="${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-10.0/compat"
+
+# Load everything we need to build the custom layer and stuff required by opencv.
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  cmake \
+  g++ \
+  libsm6 \
+  libxext6 \
+  libxrender-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Setup our build paths
+RUN mkdir -p /build
+COPY custom_layer /build/custom_layer 
+RUN mkdir -p /build/custom_layer/build
+
+# Compile the new layer
+WORKDIR /build/custom_layer/build
+RUN cmake -D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda ..
+RUN make -j
+
+# Install the python requirements.
+COPY requirements.txt /
+RUN  pip install -r /requirements.txt
+
+# Copy in the full repo.
+COPY . /bts
+WORKDIR /bts
+
+# Put the new layer we built into /bts/custom_layer
+RUN cp -r /build/custom_layer/build custom_layer/.
+
+# Download the model locally.
+RUN mkdir -p models \ 
+  && python utils/download_from_gdrive.py 1ipme-fkV4pIx87sOs31R9CD_Qg-85__h models/bts_nyu.zip \
+  && cd models \
+  && unzip bts_nyu.zip
+
+# Set the path back to avoid error (see above).
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH_OLD}"
+
+# Add relevant paths to the PYTHONPATH so they can be imported from anywhere.
+ENV PYTHONPATH=/bts:/bts/models/bts_nyu

--- a/bts_test.py
+++ b/bts_test.py
@@ -25,6 +25,7 @@ import errno
 import matplotlib.pyplot as plt
 import cv2
 import sys
+from tqdm import tqdm
 
 from bts_dataloader import *
 
@@ -118,7 +119,8 @@ def test(params):
         pred_2x2s = []
 
         start_time = time.time()
-        for s in range(num_test_samples):
+        print('Processing images..')
+        for s in tqdm(range(num_test_samples)):
             depth, pred_8x8, pred_4x4, pred_2x2 = sess.run([model.depth_est, model.depth_8x8, model.depth_4x4, model.depth_2x2])
             pred_depths.append(depth[0].squeeze())
 
@@ -126,15 +128,11 @@ def test(params):
             pred_4x4s.append(pred_4x4[0].squeeze())
             pred_2x2s.append(pred_2x2[0].squeeze())
 
-            print('{}/{} processing done'.format(s+1, num_test_samples))
-
-        elapsed_time = time.time() - start_time
-        print('Elapesed time: %s' % str(elapsed_time))
         print('Done.')
 
         save_name = 'result_' + args.model_name
 
-        print('Saving result pngs')
+        print('Saving result pngs..')
         if not os.path.exists(os.path.dirname(save_name)):
             try:
                 os.mkdir(save_name)
@@ -145,7 +143,7 @@ def test(params):
                 if e.errno != errno.EEXIST:
                     raise
 
-        for s in range(num_test_samples):
+        for s in tqdm(range(num_test_samples)):
             if args.dataset == 'kitti':
                 date_drive = lines[s].split('/')[1]
                 filename_png = save_name + '/raw/' + date_drive + '_' + lines[s].split()[0].split('/')[-1].replace('.jpg', '.png')
@@ -201,8 +199,6 @@ def test(params):
                 plt.imsave(filename_lpg_cmap_png, np.log10(pred_4x4), cmap='Greys')
                 filename_lpg_cmap_png = filename_cmap_png.replace('.png', '_2x2.png')
                 plt.imsave(filename_lpg_cmap_png, np.log10(pred_2x2), cmap='Greys')
-
-            print('{}/{} saving done'.format(s+1, num_test_samples))
 
         return
 

--- a/custom_layer/compute_depth.cu
+++ b/custom_layer/compute_depth.cu
@@ -19,8 +19,8 @@
 #ifdef GOOGLE_CUDA
 #define EIGEN_USE_GPU
 #include "compute_depth.h"
-// #include "tensorflow/core/util/cuda_kernel_helper.h" // tf <= 1.13.2
-#include "tensorflow/core/util/gpu_kernel_helper.h" // tf >= 1.14.0
+#include "tensorflow/core/util/cuda_kernel_helper.h" // tf <= 1.13.2
+//#include "tensorflow/core/util/gpu_kernel_helper.h" // tf >= 1.14.0
 
 using namespace tensorflow;
 

--- a/notebooks/example_nyu_v2.py.ipynb
+++ b/notebooks/example_nyu_v2.py.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wed Sep  4 03:46:01 2019       \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| NVIDIA-SMI 418.56       Driver Version: 418.56       CUDA Version: 10.1     |\r\n",
+      "|-------------------------------+----------------------+----------------------+\r\n",
+      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\r\n",
+      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\r\n",
+      "|===============================+======================+======================|\r\n",
+      "|   0  GeForce GTX TIT...  Off  | 00000000:01:00.0  On |                  N/A |\r\n",
+      "| 22%   37C    P8    15W / 250W |    413MiB / 12211MiB |      0%      Default |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "                                                                               \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| Processes:                                                       GPU Memory |\r\n",
+      "|  GPU       PID   Type   Process name                             Usage      |\r\n",
+      "|=============================================================================|\r\n",
+      "+-----------------------------------------------------------------------------+\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check that the GPU exists.\n",
+    "! nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Check: is GPU Available?\n",
+      "True\n",
+      "Note that this will still run if it's not, but it will run a lot slower.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "print(\"Check: is GPU Available?\")\n",
+    "print(tf.test.is_gpu_available())\n",
+    "print(\"Note that this will still run if it's not, but it will run a lot slower.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /bts/bts_dataloader.py:68: to_float (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.cast instead.\n",
+      "WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/python/data/ops/dataset_ops.py:1419: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n",
+      "==================================\n",
+      " upconv5 in/out: 2208 / 512\n",
+      "  iconv5 in/out: 896 / 512\n",
+      " upconv4 in/out: 512 / 256\n",
+      "  iconv4 in/out: 448 / 256\n",
+      "    aspp in/out: 896 / 128\n",
+      "reduc8x8 in/out: 128 / 4\n",
+      "  lpg8x8 in/out: 4 / 1\n",
+      " upconv3 in/out: 128 / 128\n",
+      "  iconv3 in/out: 225 / 128\n",
+      "reduc4x4 in/out: 128 / 4\n",
+      "  lpg4x4 in/out: 4 / 1\n",
+      " upconv2 in/out: 128 / 64\n",
+      "  iconv2 in/out: 161 / 64\n",
+      "reduc2x2 in/out: 64 / 4\n",
+      "  lpg2x2 in/out: 4 / 1\n",
+      " upconv1 in/out: 64 / 32\n",
+      "  iconv1 in/out: 35 / 32\n",
+      "   depth in/out: 32 / 1\n",
+      "==================================\n",
+      "WARNING:tensorflow:From bts_test.py:97: start_queue_runners (from tensorflow.python.training.queue_runner_impl) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "To construct input pipelines, use the `tf.data` module.\n",
+      "WARNING:tensorflow:`tf.train.start_queue_runners()` was called when no queue runners were defined. You can safely remove the call to this deprecated function.\n",
+      "WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/python/training/saver.py:1266: checkpoint_exists (from tensorflow.python.training.checkpoint_management) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use standard file APIs to check for files with this prefix.\n",
+      "Now testing 654 files with ./models/bts_nyu/model\n",
+      "Processing images..\n",
+      "100%|██████████| 654/654 [01:05<00:00,  9.94it/s]\n",
+      "Done.\n",
+      "Saving result pngs..\n",
+      " 38%|███▊      | 251/654 [00:56<01:30,  4.43it/s]bts_test.py:189: RuntimeWarning: divide by zero encountered in log10\n",
+      "  plt.imsave(filename_lpg_cmap_png, np.log10(pred_4x4_cropped), cmap='Greys')\n",
+      "100%|██████████| 654/654 [02:25<00:00,  4.51it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "! cd /bts && python bts_test.py  \\\n",
+    "--encoder densenet161_bts \\\n",
+    "--data_path /data/nyu_depth_v2/official_splits/test/ \\\n",
+    "--dataset nyu \\\n",
+    "--filenames_file ./train_test_inputs/nyudepthv2_test_files_with_gt.txt \\\n",
+    "--model_name bts_nyu \\\n",
+    "--checkpoint_path ./models/bts_nyu/model \\\n",
+    "--input_height 480 \\\n",
+    "--input_width 640 \\\n",
+    "--max_depth 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python
+scipy
+tqdm
+requests


### PR DESCRIPTION
I only use nvidia-docker based models to fully encapsulate the model's dependencies. I did this for myself, but it should also make it easier for others to try this out. Here's what this is doing:

* Use the latest stable docker release for tensorflow as a base: 1.13.2
* Use an GPU tensorflow version that can be run using nvidia-docker
* Adds a requirements.txt for the python dependencies, including some opencv lib dependencies.
* Build the custom layer
* Add the trained nyu model.
* Fix `PYTHONPATH` so that the bts modules can be called from anywhere.
* Provide an example jupyter notebook showing everything working (with the GPU!)
* Can be called with
 `nvidia-docker run -it -v "[PATH_TO_DATASETS]:/data" -v"$(pwd)/notebooks:/tf" -p"8888:8888"`
