### PR TITLE
Fix path joining using os module

### DIFF
--- a/pytorch/bts_test.py
+++ b/pytorch/bts_test.py
@@ -160,10 +160,10 @@ def test(params):
                 '.jpg', '.png')
             filename_image_png = save_name + '/rgb/' + scene_name + '_' + lines[s].split()[0].split('/')[1]
         
-        rgb_path = os.path.join(args.data_path, lines[s].split()[0])
+        rgb_path = os.path.join(args.data_path, './' + lines[s].split()[0])
         image = cv2.imread(rgb_path)
         if args.dataset == 'nyu':
-            gt_path = os.path.join(args.data_path, lines[s].split()[1])
+            gt_path = os.path.join(args.data_path, './' + lines[s].split()[1])
             gt = cv2.imread(gt_path, -1).astype(np.float32) / 1000.0  # Visualization purpose only
             gt[gt == 0] = np.amax(gt)
         


### PR DESCRIPTION
Fix path joining using os module (as you did in [`bts_dataloader.py`](https://github.com/cogaplex-bts/bts/blob/579cfe2ca988ec9077e3eb55eb3d22363865f1d6/pytorch/bts_dataloader.py#L100)), which otherwise doesn't join paths e.g.

```
>>> os.path.join('DepthDataset/test/', '/10_007/depth_img.png')                   
'/10_007/depth_img.png'
>>> os.path.join('DepthDataset/test', './' + '10_007/depth_img.png')              
'DepthDataset/test/./10_007/depth_img.png'
```