### PR TITLE
Fix EOFError in Pytorch for multiprocessing_distributed

### DIFF
--- a/pytorch/bts_main.py
+++ b/pytorch/bts_main.py
@@ -547,7 +547,11 @@ def main_worker(gpu, ngpus_per_node, args):
             global_step += 1
 
         epoch += 1
-
+       
+    if not args.multiprocessing_distributed or (args.multiprocessing_distributed and args.rank % ngpus_per_node == 0):
+        writer.close()
+        if args.do_online_eval:
+            eval_summary_writer.close()
 
 def main():
     if args.mode != 'train':


### PR DESCRIPTION
When training on PyTorch with multiprocessing_distributed, "/tensorboardX/event_file_writer.py" raises an EOFError. 
As far as I understand, this happens because a thread is closed without closing the SummaryWriter for Tensorboard. So the SummaryWriter tries to access data that is not there anymore and receives the End of File Error. Closing "writer" and "eval_summary_writer" after finishing the training cycle and before closing the thread fixes the issue.
